### PR TITLE
works with options now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+
+/.idea

--- a/addon/components/input-mask.js
+++ b/addon/components/input-mask.js
@@ -5,14 +5,30 @@ import Ember from 'ember';
 export default Ember.TextField.extend({
   initializeMask: function() {
     var mask = this.get('mask');
+    let params = {};
+    let self = this;
 
-    this.$().inputmask(mask, {
-      onBeforeMask: function(value) {
-        if (mask === 'mm/dd/yyyy') {
-          return moment(new Date(value)).format('L');
+    let passedParams = this.attrs;
+
+    for (let i in passedParams) {
+      if(typeof passedParams[i] !== 'undefined' && passedParams[i] !== null) {
+        if(typeof Inputmask.prototype.defaults[i] === 'function'){
+          params[i] = function() {
+            self.sendAction(i,...arguments);
+          }
+        }else {
+          params[i] = passedParams[i];
         }
       }
-    });
+    }
+
+    params.onBeforeMask = function(value) {
+      if (mask === 'mm/dd/yyyy') {
+        return moment(new Date(value)).format('L');
+      }
+    };
+
+    this.$().inputmask(mask, params);
 
     // The input mask changes the value of the input from the original to a
     // formatted version. We need to manually send that change back to the


### PR DESCRIPTION
Works with plugin's options now, including passed actions for native events like `onKeyDown`, `onBeforeMask`, etc. Working usage example:

```
{{input-mask value=maskedValue mask="9{1,5}[.9{1,2}]" showMaskOnFocus=false showMaskOnHover=false placeholder=' ' onKeyDown='kd' }}
```
