### PR TITLE
Resolve the deprecation warning: ember-views.dispatching-modify-property

### DIFF
--- a/addon/components/input-mask.js
+++ b/addon/components/input-mask.js
@@ -17,7 +17,9 @@ export default Ember.TextField.extend({
     // The input mask changes the value of the input from the original to a
     // formatted version. We need to manually send that change back to the
     // controller.
-    this.set('value', this.$().val());
+    Ember.run.scheduleOnce('afterRender', this, function() {
+      this.set('value', this.$().val());
+    });
   }.on('didInsertElement'),
 
   removeMask: function() {


### PR DESCRIPTION
Deprecation warning: A property of <appname@view:-outlet::emberxxx> was modified inside the didInsertElement hook. You should never change properties on components, services or models during didInsertElement because it causes significant performance degradation..
